### PR TITLE
Do not remove query params for non matching URLs

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -56,7 +56,5 @@ chrome.storage.sync.get(['globalEnabled', 'queryParams', 'urlMatchers'], ({globa
 
 	if (doesUrlMatch(window.location.href, matchers)) {
 		injectParams(queryParams);
-	} else {
-		clearInjectedParams(queryParams);
 	}
 });

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -14,15 +14,6 @@ function injectParams(queryParams) {
 	setUrlSearchParams(searchParams);
 }
 
-function clearInjectedParams(queryParams) {
-	let searchParams = new URLSearchParams(window.location.search);
-	
-	queryParams
-		.forEach(({key, value}) => searchParams.delete(key, value))
-
-	setUrlSearchParams(searchParams);
-}
-
 function setUrlSearchParams(searchParams) {
 	let newUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
 


### PR DESCRIPTION
If the current URL doesn't match any of the URL matchers don't manipulate the query string.